### PR TITLE
Added missing python package to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pandas
 torch
 torchvision
 torchsummary
+sounddevice


### PR DESCRIPTION
The `sounddevice` package is required for week 4.